### PR TITLE
Added botExecutionDelay Gamerule

### DIFF
--- a/src/main/java/me/codex/programmable_bots/ProgrammableBots.java
+++ b/src/main/java/me/codex/programmable_bots/ProgrammableBots.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 
 import me.codex.programmable_bots.block.ModBlocks;
 import me.codex.programmable_bots.block.entity.ModBlockEntities;
+import me.codex.programmable_bots.gamerules.ModGamerules;
 import me.codex.programmable_bots.item.ModItemGroup;
 import me.codex.programmable_bots.screen.ModScreenHandlers;
 
@@ -20,6 +21,9 @@ public class ProgrammableBots implements ModInitializer {
 
         // Blocks and Items
         ModBlocks.registerModBlocks();
+
+        // Gamerules
+        ModGamerules.registerModGamerules();
 
         // Other
         ModBlockEntities.registerBlockEntities();

--- a/src/main/java/me/codex/programmable_bots/block/entity/BotBlockEntity.java
+++ b/src/main/java/me/codex/programmable_bots/block/entity/BotBlockEntity.java
@@ -102,10 +102,9 @@ public class BotBlockEntity extends BlockEntity implements NamedScreenHandlerFac
             return;
         }
 
-        if (entity.executionDelay < 0) {
-            entity.executionDelay = 0;
+        if (world.getGameRules().getInt(ModGamerules.BOT_EXECUTION_DELAY) != entity.executionDelay) {
+            entity.executionDelay = world.getGameRules().getInt(ModGamerules.BOT_EXECUTION_DELAY);
         }
-        entity.executionDelay = world.getGameRules().getInt(ModGamerules.BOT_EXECUTION_DELAY);
 
         boolean canRunCode = entity.hasBook() && !entity.executingBook && world.getTime() > entity.lastRan;
         if (canRunCode) {

--- a/src/main/java/me/codex/programmable_bots/block/entity/BotBlockEntity.java
+++ b/src/main/java/me/codex/programmable_bots/block/entity/BotBlockEntity.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import org.jetbrains.annotations.Nullable;
 
 import me.codex.programmable_bots.block.BotBlock;
+import me.codex.programmable_bots.gamerules.ModGamerules;
 import me.codex.programmable_bots.screen.BotBlockScreenHandler;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
@@ -30,7 +31,7 @@ public class BotBlockEntity extends BlockEntity implements NamedScreenHandlerFac
     private boolean executingBook = false;
     private int bookLineIndex = 0;
     private long lastRan = 0;
-    private long DELAY = 10;
+    private long executionDelay = -1;
 
     public BotBlockEntity(BlockPos pos, BlockState state) {
         super(ModBlockEntities.BOT, pos, state);
@@ -101,9 +102,14 @@ public class BotBlockEntity extends BlockEntity implements NamedScreenHandlerFac
             return;
         }
 
-        var canRunCode = entity.hasBook() && !entity.executingBook && world.getTime() > entity.lastRan;
+        if (entity.executionDelay < 0) {
+            entity.executionDelay = 0;
+        }
+        entity.executionDelay = world.getGameRules().getInt(ModGamerules.BOT_EXECUTION_DELAY);
+
+        boolean canRunCode = entity.hasBook() && !entity.executingBook && world.getTime() > entity.lastRan;
         if (canRunCode) {
-            entity.lastRan = world.getTime() + entity.DELAY;
+            entity.lastRan = world.getTime() + entity.executionDelay;
             entity.executingBook = true;
             ItemStack stack = entity.getStack(0);
             NbtElement pages = stack.getNbt().get("pages");

--- a/src/main/java/me/codex/programmable_bots/gamerules/ModGamerules.java
+++ b/src/main/java/me/codex/programmable_bots/gamerules/ModGamerules.java
@@ -1,0 +1,17 @@
+package me.codex.programmable_bots.gamerules;
+
+import me.codex.programmable_bots.ProgrammableBots;
+import net.fabricmc.fabric.api.gamerule.v1.GameRuleFactory;
+import net.fabricmc.fabric.api.gamerule.v1.GameRuleRegistry;
+import net.minecraft.world.GameRules;
+import net.minecraft.world.GameRules.Category;
+
+public class ModGamerules {
+    public static final GameRules.Key<GameRules.IntRule> BOT_EXECUTION_DELAY = GameRuleRegistry.register("botExecutionDelay",
+        Category.UPDATES,
+        GameRuleFactory.createIntRule(8));
+
+    public static void registerModGamerules() {
+        ProgrammableBots.LOGGER.debug("Registering mod gamerules for "+ProgrammableBots.MODID);
+    }
+}

--- a/src/main/java/me/codex/programmable_bots/gamerules/ModGamerules.java
+++ b/src/main/java/me/codex/programmable_bots/gamerules/ModGamerules.java
@@ -9,7 +9,7 @@ import net.minecraft.world.GameRules.Category;
 public class ModGamerules {
     public static final GameRules.Key<GameRules.IntRule> BOT_EXECUTION_DELAY = GameRuleRegistry.register("botExecutionDelay",
         Category.UPDATES,
-        GameRuleFactory.createIntRule(8));
+        GameRuleFactory.createIntRule(8, 0));
 
     public static void registerModGamerules() {
         ProgrammableBots.LOGGER.debug("Registering mod gamerules for "+ProgrammableBots.MODID);

--- a/src/main/resources/assets/programmable_bots/lang/en_us.json
+++ b/src/main/resources/assets/programmable_bots/lang/en_us.json
@@ -1,5 +1,7 @@
 {
     "block.programmable_bots.bot": "Bot",
 
-    "itemGroup.programmable_bots.tab": "Programmable Bots"
+    "itemGroup.programmable_bots.tab": "Programmable Bots",
+
+    "gamerule.botExecutionDelay": "Execution delay of bots from the Programmable Bots Mod"
 }


### PR DESCRIPTION
Adds a new gamerule that allows you to control how fast or slow the bot executes code from the book.

* Gamerule: `/gamerule botExecutionDelay <int>`
* Has a minimum value of 0
* Default value has been changed to 8 from 10